### PR TITLE
Refactor str calls in composer.py

### DIFF
--- a/composer.py
+++ b/composer.py
@@ -30,7 +30,7 @@ async def spawn_challenge(challenge, environment_variables=None):
         subprocess.run(["docker-compose", "-f", "instances/" + instance_id + "/docker-compose.yml", "push"], env=environment_variables)
         subprocess.run(["docker", "stack", "deploy", "--compose-file", "instances/" + instance_id + "/docker-compose.yml", instance_id, "--with-registry-auth"], env=environment_variables)
 
-        environment_variables["IP"] = str(socket.gethostbyname(socket.gethostname()))
+        environment_variables["IP"] = socket.gethostbyname(socket.gethostname())
         response = {
             "instance_id": instance_id,
             "challenge": challenge,

--- a/composer.py
+++ b/composer.py
@@ -39,6 +39,6 @@ async def spawn_challenge(challenge, environment_variables=None):
         print(f"{instance_id} - {challenge} - {environment_variables} - done")
         return response
     except Exception as e:
-        error = {"error": str(e)}
+        error = {"error": repr(e)}
         print(f"{instance_id} - {challenge} - {environment_variables} - error - {error}")
         return error


### PR DESCRIPTION
With this PR I would like to remove/refactor two calls to `str()`

The first str-call is not needed, as `socket.gethostbyname` already returns the hostname as string.
```python
>>> import socket
>>> type(socket.gethostbyname(socket.gethostname()))
<class 'str'>
```

Using `str()` on an object of type exception only returns the error-message but not the exception type
```python
>>> try:
...     10/0
... except Exception as e:
...     print(str(e))
... 
division by zero
```
while `repr` returns the exception type as well.
```python
>>> try:
...     10/0
... except Exception as e:
...     print(repr(e))
... 
ZeroDivisionError('division by zero')
```
Since the type of exception that shall be catched is not specified, I assume that the later might be better for troubleshooting.  
Since I wasn't sure if this wasn't intentional, I made the change in a separate commit, please feel free to cherry-pick.